### PR TITLE
Add preview styles and templates

### DIFF
--- a/files/admin/index.html
+++ b/files/admin/index.html
@@ -11,6 +11,24 @@
   <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
   <script>
     CMS.registerPreviewStyle("/assets/css/all-nocdn.css");
+
+    var PostPreview = createClass({
+      render: function() {
+        var entry = this.props.entry;
+        return h('article', {"className": "post-text h-entry hentry postpage"},
+          h('header', {},
+            h('h1', {"className": "p-name entry-title"},
+              h('a', {"href": ".", "className": "u-url"}, entry.getIn(['data', 'title']))),
+            h('div', {"className": "metadata"},
+              h('p', {"className": "byline author vcard p-author h-card"},
+                h('span', {"className": "byline-name fn p-name"}, entry.getIn(['data', 'author']) || ' ')))),
+          h('div', {"className": "e-content entry-content"}, this.props.widgetFor('body'))
+        );
+      }
+  });
+
+    CMS.registerPreviewTemplate("posts", PostPreview);
+    CMS.registerPreviewTemplate("pages", PostPreview);
   </script>
 </body>
 </html>

--- a/files/admin/index.html
+++ b/files/admin/index.html
@@ -9,5 +9,8 @@
 <body>
   <!-- Include the script that builds the page and powers Netlify CMS -->
   <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
+  <script>
+    CMS.registerPreviewStyle("/assets/css/all-nocdn.css");
+  </script>
 </body>
 </html>


### PR DESCRIPTION
This PR adds the styles and templates used by Nikola to the edit window in the Netlify CMS admin. This makes the edit page look pretty close to the actual output.

This PR should probably be applied after #15, since it refers to the "author" field that gets added in that PR.